### PR TITLE
errors 🥰

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,14 @@ fn main() {
 	let args: Vec<String> = env::args().collect();
 
 	let date = if args.len() > 1 {
-		match NaiveDate::parse_from_str(&args[1], "%Y-%m-%d") {
-			Ok(a) => a,
-			Err(_) => {
-				eprintln!("ERROR: Input date must follow format YYYY-MM-DD");
-				exit(-1);
-			}
-		}
+		NaiveDate::parse_from_str(&args[1], "%Y-%m-%d").unwrap_or_else(|err| {
+			eprintln!(
+				"ERROR: {err} > \"{}\" \n\
+				\0└╴     Date must follow format \"YYYY-MM-DD\"",
+				&args[1]
+			);
+			exit(-1);
+		})
 	} else {
 		Local::now().date().naive_local()
 	};


### PR DESCRIPTION
I changed how errors are displayed.
They are, imho, nicer and more descriptive :3

```diff
$ june 2023-13-01
- ERROR: Input date must follow format YYYY-MM-DD

+ ERROR: input is out of range > "2023-13-01"
+ └╴     Date must follow format "YYYY-MM-DD"
```

```diff
$ june 2023-01-1235
- ERROR: Input date must follow format YYYY-MM-DD

+ ERROR: trailing input > "2023-01-1235"
+ └╴     Date must follow format "YYYY-MM-DD"
```

also `unwrap_or_else` is cleaner than `match`; whops.