### PR TITLE
remove vector allocation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,12 @@ use chrono::{Datelike, Local, NaiveDate};
 use std::{env, process::exit};
 
 fn main() {
-	let args: Vec<String> = env::args().collect();
-
-	let date = if args.len() > 1 {
-		NaiveDate::parse_from_str(&args[1], "%Y-%m-%d").unwrap_or_else(|err| {
+	let date = if let Some(arg) = env::args().nth(1) {
+		NaiveDate::parse_from_str(&arg, "%Y-%m-%d").unwrap_or_else(|err| {
 			eprintln!(
 				"ERROR: {err} > \"{}\" \n\
 				\0└╴     Date must follow format \"YYYY-MM-DD\"",
-				&args[1]
+				&arg
 			);
 			exit(-1);
 		})


### PR DESCRIPTION
The arguments where previously put in a `Vec<String>`, but an iterator can be used instead since they return an option.
An added benefit of this is that it is no longer necessary to do a check on the vector length and index into it.